### PR TITLE
#19 - osiv 옵션 해제

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,7 @@ spring:
     password: asdfadsf!@#$
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
+    open-in-view: false
     defer-datasource-initialization: true
     hibernate.ddl-auto: create
     show-sql: true


### PR DESCRIPTION
스프링부트 경고 로그를 끄고, 더 나을 설꼐를 위해
(영속성 컨텍스트가 트랜잭션 범위 안에서 종료되게끔)
osiv 설정을 끈다.