### PR TITLE
DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/org/example/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/org/example/projectboard/dto/response/ArticleCommentResponse.java
@@ -11,7 +11,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/src/main/java/org/example/projectboard/dto/response/ArticleResponse.java
+++ b/src/main/java/org/example/projectboard/dto/response/ArticleResponse.java
@@ -13,7 +13,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/src/main/java/org/example/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/org/example/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -18,7 +18,7 @@ public record ArticleWithCommentsResponse(
         String nickname,
         Set<String> hashtags, // 추가된 필드
         Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+) {
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<String> hashtags, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, hashtags, articleCommentResponses);


### PR DESCRIPTION
JPA Buddy 를 이용해 작성한 DTO들인데,
자동으로 implements Serializable 이 들어가버림
프로젝트는 직렬화로 Jackson을 사용하므로 필요하지 않고, 의도하여 넣은 코드도 아님 그러므로 삭제